### PR TITLE
Change deploy strategy for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '0.10'
 deploy:
   provider: heroku
+  strategy: git
   api_key:
     secure: n7MQejUxkS1zdZ5BoMOSfM5VoJewawuJJYOc6FHY2oqnwzdEXc6ATcTYO9TJl7hEa9tB6lAhi92ju8u0Qs1hdvrlpQxLyJ/j3kgW8LqEW8Fr8lhI24zAQgvvdbqCTBpS05GcXRHLVmQ1bnTTqARD0d7TjGxqlhh9GXN1j03F96A=
   app:


### PR DESCRIPTION
怒られたしよく失敗するので変更してみる

```
The default strategy for Heroku deployments is currently "anvil".
This will be changed to "api" in the near future.
Consider setting it explicitly to "api" or "git".

```
