### PR TITLE
夜勤用 Heroku app への deploy 設定を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,19 @@ language: node_js
 node_js:
 - '0.10'
 deploy:
-  provider: heroku
-  strategy: git
-  api_key:
-    secure: n7MQejUxkS1zdZ5BoMOSfM5VoJewawuJJYOc6FHY2oqnwzdEXc6ATcTYO9TJl7hEa9tB6lAhi92ju8u0Qs1hdvrlpQxLyJ/j3kgW8LqEW8Fr8lhI24zAQgvvdbqCTBpS05GcXRHLVmQ1bnTTqARD0d7TjGxqlhh9GXN1j03F96A=
-  app:
-    master: kanmu-hubot
-  on:
-    repo: kanmu/kanmukun
+  - provider: heroku
+    strategy: git
+    api_key:
+      secure: n7MQejUxkS1zdZ5BoMOSfM5VoJewawuJJYOc6FHY2oqnwzdEXc6ATcTYO9TJl7hEa9tB6lAhi92ju8u0Qs1hdvrlpQxLyJ/j3kgW8LqEW8Fr8lhI24zAQgvvdbqCTBpS05GcXRHLVmQ1bnTTqARD0d7TjGxqlhh9GXN1j03F96A=
+    app:
+      master: kanmu-hubot
+    on:
+      repo: kanmu/kanmukun
+  - provider: heroku
+    strategy: git
+    api_key:
+      secure: n7MQejUxkS1zdZ5BoMOSfM5VoJewawuJJYOc6FHY2oqnwzdEXc6ATcTYO9TJl7hEa9tB6lAhi92ju8u0Qs1hdvrlpQxLyJ/j3kgW8LqEW8Fr8lhI24zAQgvvdbqCTBpS05GcXRHLVmQ1bnTTqARD0d7TjGxqlhh9GXN1j03F96A=
+    app:
+      master: kanmu-hubot-nightshift
+    on:
+      repo: kanmu/kanmukun


### PR DESCRIPTION
heroku の無料枠縮小 (1日18hまで) に対応するため夜勤用の heroku app を追加.
Process Scheduler により 08:00 - 01:00 は通常勤務, 01:00 - 08:00 は夜勤の app に切り替える.

Refs:
- [HerokuでHubotを指定の時間に寝かせる - はらへり日記](http://sota1235.hatenablog.com/entry/2015/06/10/130000)
- [Herokuが新料金を発表。無料Dynoの制限が変わる - iyuichiの私的開発ログ](http://iyuichi.hatenablog.jp/entry/2015/05/14/heroku-new-pricing-free-dyno)