### PR TITLE
Update hubot-misawa to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hubot-kanmu": "git://github.com/ideyuta/hubot-kanmu#v1.1.2",
     "hubot-lgtm": "git://github.com/bouzuya/hubot-lgtm#1.0.0",
     "hubot-maps": "0.0.2",
-    "hubot-misawa": "0.0.3",
+    "hubot-misawa": "0.1.1",
     "hubot-mstr": "git://github.com/bouzuya/hubot-mstr#1.0.1",
     "hubot-nullpo": "0.0.3",
     "hubot-piptools": "git://github.com/achiku/hubot-piptools#0.0.6",


### PR DESCRIPTION
- horesase-boys の URL が変わって使えなくなってた: moqada/hubot-misawa#3
- 地味に PR で bomb 機能が追加されてた: moqada/hubot-misawa#2