### PR TITLE
Add hubot-regex-response

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ HUBOT_KANJO_AWS_SECRET_KEY    <AWS_SECRET_KEY_FOR_BILLING>
 # for hubot-nullpo
 HUBOT_NULLPO_RESPONSE_STYLE: rich
 
+# for hubot-regex-response
+HUBOT_REGEX_RESPONSE_CONFIGS  '[{"from":"Contributions:(?:.+)\nLongest Streak:(?:.+)\nCurrent Streak:(?:.+)\n(https://[\\S]+)","to":"<%= m[1] %>"}]'
+
 # for hubot-shuzo
 HUBOT_SHUZO_WORDS:           (無理|むり|ムリ)|(でき|出来)(ない|ません|ん|っこない)|(でき|出来)る気が?(しない|しません|せん)
 

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -21,6 +21,7 @@
   "hubot-piptools",
   "hubot-pugme",
   "hubot-redis-brain",
+  "hubot-regex-response",
   "hubot-rules",
   "hubot-schedule",
   "hubot-shinchoku",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "hubot-piptools": "git://github.com/achiku/hubot-piptools#0.0.6",
     "hubot-pugme": "^0.1.0",
     "hubot-redis-brain": "0.0.3",
+    "hubot-regex-response": "^1.0.0",
     "hubot-rules": "^0.1.1",
     "hubot-schedule": "^0.4.0",
     "hubot-scripts": "^2.16.1",


### PR DESCRIPTION
hubot-github-contribution-stats 補助用

- HipChat上ではGitHub URLと画像URL両方をメッセージに含めると片方しか展開されない
- 正規表現でhubot-github-contribution-statsの発言を拾って画像URLだけ再投稿するようにした