### PR TITLE
Update hubot-github-contribution-stats to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ HUBOT_5ROLLI_TRELLO_API_TOKEN <TRELLO_API_TOKEN>
 
 # for hubot-github-contribution-stats
 HUBOT_GITHUB_CONTRIBUTION_STATS_GYAZO_TOKEN <GYAZO_API_TOKEN>
+HUBOT_GITHUB_CONTRIBUTION_STATS_RESEND_GRAPH 1
 
 # for hubot-google-images
 HUBOT_GOOGLE_CSE_ID          <CSE_ID>
@@ -46,9 +47,6 @@ HUBOT_KANJO_AWS_SECRET_KEY    <AWS_SECRET_KEY_FOR_BILLING>
 
 # for hubot-nullpo
 HUBOT_NULLPO_RESPONSE_STYLE: rich
-
-# for hubot-regex-response
-HUBOT_REGEX_RESPONSE_CONFIGS  '[{"from":"Contributions:(?:.+)\nLongest Streak:(?:.+)\nCurrent Streak:(?:.+)\n(https://[\\S]+)","to":"<%= m[1] %>"}]'
 
 # for hubot-shuzo
 HUBOT_SHUZO_WORDS:           (無理|むり|ムリ)|(でき|出来)(ない|ません|ん|っこない)|(でき|出来)る気が?(しない|しません|せん)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hubot-5rolli": "^0.2.0",
     "hubot-alias": "^0.1.6",
     "hubot-diagnostics": "0.0.1",
-    "hubot-github-contribution-stats": "^0.4.0",
+    "hubot-github-contribution-stats": "^0.4.1",
     "hubot-google-images": "^0.2.3",
     "hubot-google-translate": "^0.2.0",
     "hubot-gyazo": "0.0.2",


### PR DESCRIPTION
- 画像とGitHubリンクがHipChat上でも一応表示されるように変更した
  - ただし画像とメッセージ本文の投稿が前後する場合あり