### PR TITLE
chore(package): Update hubot-hatena-counting to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/kanmu/kanmukun.git"
   },
   "dependencies": {
-    "@moqada/hubot-hatena-counting": "1.0.0",
+    "@moqada/hubot-hatena-counting": "1.0.2",
     "coffee-script": "1.10.0",
     "hubot": "^2.18.0",
     "hubot-5rolli": "0.2.0",


### PR DESCRIPTION
- Greenkeeperがscoped packageのUpdateにはまだ未対応なので手動PR
- 不具合修正
  - https://github.com/moqada/hubot-hatena-counting/releases/tag/v1.0.1
  - https://github.com/moqada/hubot-hatena-counting/releases/tag/v1.0.2